### PR TITLE
Use s instead of " for seconds

### DIFF
--- a/bot/utilities/helpers.py
+++ b/bot/utilities/helpers.py
@@ -119,7 +119,7 @@ def recognize_voice(
         avg_response_time = transcription_request.estimated_duration(session, voice.duration)
         text = "<i>Inizio trascrizione... Per i vocali >1 minuto potrebbe volerci un po' di più</i>"
         if avg_response_time:
-            text = text.replace("</i>", f" (stimato: {round(avg_response_time, 1)}\")</i>")
+            text = text.replace("</i>", f" (stimato: {round(avg_response_time, 1)} s)</i>")
 
     message_to_edit = update.message.reply_html(text, disable_notification=True, quote=True)
 


### PR DESCRIPTION
" is the symbol for [second of arc](https://en.wikipedia.org/wiki/Minute_and_second_of_arc). The correct symbol for the [second](https://en.wikipedia.org/wiki/Second) as a unit of time is s.

It's a non-issue, because it would be clear anyway, but it's a matter of pedantry.